### PR TITLE
Changed int to long in PayloadLength to support large files

### DIFF
--- a/src/main/resources/com/tresys/nitf/xsd/nitf.dfdl.xsd
+++ b/src/main/resources/com/tresys/nitf/xsd/nitf.dfdl.xsd
@@ -675,7 +675,7 @@ The message root is 'NITF'.
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
-                    <xs:element name="PayloadLength" type="xs:int" dfdl:inputValueCalc="{ (../../../Header/ImageSegmentLengths[dfdl:occursIndex()]/DataLength) - (if (fn:exists(../MaskTable)) then dfdl:valueLength(../MaskTable[1], 'bytes') else 0) }" />
+                    <xs:element name="PayloadLength" type="xs:long" dfdl:inputValueCalc="{ (../../../Header/ImageSegmentLengths[dfdl:occursIndex()]/DataLength) - (if (fn:exists(../MaskTable)) then dfdl:valueLength(../MaskTable[1], 'bytes') else 0) }" />
                     <xs:choice dfdl:choiceDispatchKey="{ ../Header/ImageCompression }">
                       <xs:element ref="JFIF" dfdl:choiceBranchKey="C3 M3 C5 M5 I1" dfdl:lengthKind="explicit" dfdl:length="{ ../PayloadLength }" />
                       <xs:element name="JPEG2000" dfdl:choiceBranchKey="C8 M8" type="xs:hexBinary" dfdl:lengthKind="explicit" dfdl:length="{ ../PayloadLength }" />


### PR DESCRIPTION
Files larger than "xs:int" bytes cause this error (using an 8GB test file):

[error] Parse Error: Failed to populate ImageSegment[1]. Cause: Parse Error: Cannot convert '8280000000' from Long type to Int (Value '8280000000' is out of range for type: xs:int). (within Expression Evaluation Error: Cannot convert '8280000000' from Long type to Int (Value '8280000000' is out of range for type: xs:int).
Schema context: PayloadLength Location line 679 column 22 in file:/home/bnordin/Images/NITF/nitf.dfdl.xsd)
Schema context: PayloadLength Location line 679 column 22 in file:/home/bnordin/Images/NITF/nitf.dfdl.xsd
Schema context: sequence[1] Location line 154 column 8 in file:/home/bnordin/Images/NITF/nitf.dfdl.xsd
Data location was preceding byte 843
[error] Parse Error: Cannot convert '8280000000' from Long type to Int (Value '8280000000' is out of range for type: xs:int). (within Expression Evaluation Error: Cannot convert '8280000000' from Long type to Int (Value '8280000000' is out of range for type: xs:int).
Schema context: PayloadLength Location line 679 column 22 in file:/home/bnordin/Images/NITF/nitf.dfdl.xsd)
Schema context: PayloadLength Location line 679 column 22 in file:/home/bnordin/Images/NITF/nitf.dfdl.xsd

The proposed change makes the obvious change from xs:int to xs:long in PayloadLength