### PR TITLE
Fix reliance on incorrect default property resolution

### DIFF
--- a/src/main/resources/com/tresys/nitf/xsd/nitf_extension_types.dfdl.xsd
+++ b/src/main/resources/com/tresys/nitf/xsd/nitf_extension_types.dfdl.xsd
@@ -89,7 +89,9 @@ in NITF, such as TaggedRecordExtensions and ImageData formats.
             <dfdl:setVariable ref="nitf:payloadSizeInBytes" value="{ PayloadLength }" />
           </xs:appinfo>
         </xs:annotation>
-        <xs:element ref="JFIF" dfdl:choiceBranchKey="C3 M3 C5 M5 I1" dfdl:lengthKind="explicit" dfdl:length="{ ../PayloadLength }" />
+        <xs:element ref="JFIF" dfdl:choiceBranchKey="C3 M3 C5 M5 I1"
+          dfdl:lengthUnits="bytes" dfdl:lengthKind="explicit" dfdl:length="{ ../PayloadLength }"
+          dfdl:fillByte="%NUL;" />
         <xs:element name="JPEG2000" dfdl:choiceBranchKey="C8 M8" type="nitfc:hexBinaryOrBlob" />
         <xs:element name="BiLevel" dfdl:choiceBranchKey="C1 M1" type="nitfc:hexBinaryOrBlob" />
         <xs:element name="VectorQuantization" dfdl:choiceBranchKey="C4 M4" type="nitfc:hexBinaryOrBlob" />


### PR DESCRIPTION
According to the DFDL spec, default property resolution for the JFIF element reference should give precedence to the JFIF default properties. (i.e. innermost components win).

But the JFIF element assumes lengthUnits="bytes" (which is the default for the NITF schema), but the JFIF schema defaults to lengthUnits="bits". Since the JFIF schema default should win precedence, we need to explicitly override this in the NITF schema. We also do this for fillByte, which also differs in the JFIF and NITF schema.

Note that this isn't necessary on older versions of Daffodil since it has incorrect default property precedence logic. But newer versions of Daffodil fix this and so requires us to expilcitly override the default properties.